### PR TITLE
Add .env.example documenting runtime environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,55 @@
+# =============================================================================
+# REQUIRED
+# =============================================================================
+# Aucune variable n'est strictement requise actuellement:
+# toutes les variables lues via process.env dans shared/config.js ont une
+# valeur par défaut définie dans le code.
+
+# =============================================================================
+# OPTIONAL
+# =============================================================================
+
+# Port HTTP utilisé par le serveur Node.js.
+PORT=4000
+
+# URL de l'instance Supabase utilisée par l'application.
+SUPABASE_URL=https://your-project-id.supabase.co
+
+# Clé API Supabase (service role ou anon selon votre usage).
+SUPABASE_KEY=your-supabase-api-key
+
+# URL du service d'embedding utilisé pour vectoriser les contenus.
+EMBEDDER_URL=http://localhost:8081
+
+# Chemin racine local des documents du manuel.
+MANUAL_ROOT=/manual-docs
+
+# Token d'authentification attendu pour accéder aux endpoints Bruce.
+BRUCE_AUTH_TOKEN=your-bruce-auth-token
+
+# URL de base de l'API LLM appelée par Bruce.
+BRUCE_LLM_API_BASE=https://api.example-llm.com/v1
+
+# Nom/identifiant du modèle LLM par défaut.
+BRUCE_LLM_MODEL=gpt-4o-mini
+
+# Clé API pour le provider LLM principal.
+BRUCE_LLM_API_KEY=your-llm-api-key
+
+# Clé LiteLLM (si utilisation d'un proxy LiteLLM).
+BRUCE_LITELLM_KEY=your-litellm-key
+
+# Nombre maximal de caractères acceptés par message utilisateur.
+BRUCE_MAX_MESSAGE_CHARS=8000
+
+# Timeout maximal (en millisecondes) pour les appels au LLM.
+BRUCE_LLM_TIMEOUT_MS=15000
+
+# Nombre maximal de requêtes LLM traitées en parallèle.
+BRUCE_MAX_CONCURRENT=3
+
+# Fichier de log de secours quand l'appel LLM principal échoue.
+BRUCE_FALLBACK_LOG_PATH=./bruce-fallback.log
+
+# Source par défaut utilisée par Bruce (ex: openwebui).
+BRUCE_SOURCE_DEFAULT=openwebui


### PR DESCRIPTION
### Motivation
- Provide a clear example `.env` for new contributors because there was no `.env.example` in the repository and `shared/config.js` is the source of truth for runtime env vars. 
- Explicitly document which variables are required vs optional so callers know what to configure before running the app.

### Description
- Added a root `.env.example` that lists every environment variable read from `shared/config.js` with safe example placeholder values. 
- Each variable has a short comment describing its role and the file groups variables into `REQUIRED` and `OPTIONAL` sections based on whether `shared/config.js` sets a default. 
- All `BRUCE_*`, `SUPABASE_*`, `EMBEDDER_URL`, `MANUAL_ROOT`, `PORT`, and related LLM configuration variables are included with example values.

### Testing
- Ran `rg "process\.env" server.js shared` to locate all environment variable usages and confirmed all entries are present in `shared/config.js`, which succeeded. 
- Printed and inspected the new `.env.example` to verify it contains the extracted variables and explanatory comments, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c34072b48327bf5c7f70a3014258)