### PR TITLE
fix(gateway): return 500 on integrity timeout error in /bruce/integrity

### DIFF
--- a/routes/infra.js
+++ b/routes/infra.js
@@ -324,7 +324,7 @@ router.get('/bruce/integrity', async (req, res) => {
       new Promise((_, reject) => setTimeout(() => reject(new Error('global_integrity_timeout')), GLOBAL_TIMEOUT_MS))
     ]);
   } catch (e) {
-    return res.json({
+    return res.status(500).json({
       ok: false, generated_at: new Date().toISOString(),
       checks: { _timeout: { ok: false, error: 'Global timeout after ' + GLOBAL_TIMEOUT_MS + 'ms' } },
       elapsed_ms: Date.now() - globalStart,


### PR DESCRIPTION
### Motivation
- Certaines routes retournaient `{ ok: false }` avec HTTP 200 implicite ce qui fausse le monitoring Prometheus; la route `/bruce/integrity` retournait implicitement 200 en cas de timeout global.

### Description
- Ajout de `res.status(500)` avant le `json(...)` dans le `catch` de `/bruce/integrity` pour renvoyer explicitement HTTP 500 sans modifier la structure JSON ni la logique métier.

### Testing
- Audits automatisés effectués: `rg -n "ok\s*:\s*false" routes/*.js`, plusieurs scans Python personnalisés pour détecter `res.json({ ok: false })` sans `res.status(...)`, `git diff` et validation du fichier modifié; tous ont confirmé l'unique occurrence et la correction (succès).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c337203883278bc44e283deb6298)