### PR TITLE
Annotate disabled Supabase and exec audit no-op functions

### DIFF
--- a/shared/exec-security.js
+++ b/shared/exec-security.js
@@ -57,7 +57,8 @@ function validateExecCommand(cmd) {
  * Log audit entry to Supabase bruce_audit_log (fire-and-forget).
  */
 function auditLog(endpoint, caller, host, cmd, result, durationMs) {
-  return; // [840] disabled: ghost table bruce_audit_log (0 rows)
+  // DISABLED: table bruce_audit_log inexistante/vidée, voir [840].
+  return;
   if (!SUPABASE_URL || !SUPABASE_KEY) return;
 
   const base = String(SUPABASE_URL).replace(/\/+$/, '');

--- a/shared/supabase-client.js
+++ b/shared/supabase-client.js
@@ -3,7 +3,8 @@ const { SUPABASE_URL, SUPABASE_KEY } = require('./config');
 const { utcNowIso, logFallback, isSupabaseConfigured } = require('./helpers');
 
 async function insertMemoryEvent(source, eventType, payload) {
-  return null; // [840] disabled: ghost table memory_events (0 rows)
+  // DISABLED: table memory_events inexistante/vidée, voir [840].
+  return null;
   if (!isSupabaseConfigured()) {
     await logFallback({
       kind: 'supabase_memory_events_skipped',
@@ -80,7 +81,8 @@ async function insertMemoryEvent(source, eventType, payload) {
 }
 
 async function insertConversationMessage(eventId, conversationId, role, content) {
-  return; // [840] disabled: ghost table conversation_messages (0 rows)
+  // DISABLED: table conversation_messages inexistante/vidée, voir [840].
+  return;
   if (!isSupabaseConfigured() || !eventId) {
     await logFallback({
       kind: 'supabase_conversation_messages_skipped',


### PR DESCRIPTION
### Motivation
- Clarifier que certaines fonctions restent volontairement inactives car les tables ciblées sont absentes/vidées (réf. [840]) afin d'éviter que leur comportement trompe les appelants.

### Description
- Ajout de commentaires explicites `// DISABLED: ...` avant les `return` immédiats dans `insertMemoryEvent` et `insertConversationMessage` (`shared/supabase-client.js`) et dans `auditLog` (`shared/exec-security.js`) sans réactiver la logique ni créer de tables.

### Testing
- Chargement des modules via `node -e "require('./shared/supabase-client'); require('./shared/exec-security'); console.log('ok')"` a été exécuté et renvoie `ok` (succès).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c32c999483279d75d781f71e12aa)