### PR TITLE
fix(chat): add missing fs import in routes/chat

### DIFF
--- a/routes/chat.js
+++ b/routes/chat.js
@@ -4,6 +4,7 @@
 const express = require('express');
 const router = express.Router();
 const { randomUUID } = require('crypto');
+const fs = require('fs');
 const { validateBruceAuth } = require('../shared/auth');
 const {
   SUPABASE_URL, SUPABASE_KEY, BRUCE_LLM_API_BASE, BRUCE_LLM_API_KEY,


### PR DESCRIPTION
### Motivation
- Ensure the two existing `fs.readFileSync` calls in `routes/chat.js` can run without throwing due to a missing import. 

### Description
- Added the import `const fs = require('fs');` to the top-of-file imports in `routes/chat.js` and verified the file only uses `fs` in the two expected `readFileSync` places. 

### Testing
- No automated tests were executed for this trivial import change; no runtime test suite was run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c31debac83279fe2884221e48e81)