### PR TITLE
Add Jest unit tests for shared auth/helpers/exec-security

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "bruce",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -1,0 +1,131 @@
+'use strict';
+
+const crypto = require('crypto');
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+describe('shared/auth validateBruceAuth', () => {
+  const originalEnv = process.env;
+  let setIntervalSpy;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    setIntervalSpy = jest.spyOn(global, 'setInterval').mockImplementation(() => 0);
+  });
+
+  afterEach(() => {
+    setIntervalSpy.mockRestore();
+    process.env = originalEnv;
+    delete global.fetch;
+  });
+
+  test('extracts token from Authorization Bearer header (legacy token)', () => {
+    process.env.BRUCE_AUTH_TOKEN = 'legacy-token';
+    global.fetch = jest.fn();
+
+    const { validateBruceAuth } = require('../../shared/auth');
+    const result = validateBruceAuth({
+      headers: { authorization: 'Bearer legacy-token' },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: true,
+        client_type: 'legacy',
+      })
+    );
+  });
+
+  test('extracts token from x-bruce-token header (legacy token)', () => {
+    process.env.BRUCE_AUTH_TOKEN = 'legacy-token';
+    global.fetch = jest.fn();
+
+    const { validateBruceAuth } = require('../../shared/auth');
+    const result = validateBruceAuth({
+      headers: { 'x-bruce-token': 'legacy-token' },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.client_type).toBe('legacy');
+  });
+
+  test('rejects when token is missing', () => {
+    process.env.BRUCE_AUTH_TOKEN = 'legacy-token';
+    global.fetch = jest.fn();
+
+    const { validateBruceAuth } = require('../../shared/auth');
+    const result = validateBruceAuth({ headers: {} });
+
+    expect(result).toEqual(
+      expect.objectContaining({ ok: false, status: 401 })
+    );
+    expect(result.error).toMatch(/Missing auth token/);
+  });
+
+  test('rejects when token is invalid', () => {
+    process.env.BRUCE_AUTH_TOKEN = 'legacy-token';
+    global.fetch = jest.fn();
+
+    const { validateBruceAuth } = require('../../shared/auth');
+    const result = validateBruceAuth({
+      headers: { authorization: 'Bearer wrong-token' },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({ ok: false, status: 401, error: 'Invalid auth token' })
+    );
+  });
+
+  test('enforces per-token rate limiting from cached token metadata', async () => {
+    process.env.BRUCE_AUTH_TOKEN = '';
+    process.env.SUPABASE_URL = 'https://supabase.local';
+    process.env.SUPABASE_KEY = 'service-key';
+
+    const rawToken = 'cache-token';
+    const tokenHash = sha256(rawToken);
+
+    global.fetch = jest.fn((url, options = {}) => {
+      if (String(url).includes('/bruce_api_tokens?active=eq.true')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [
+            {
+              token_hash: tokenHash,
+              client_type: 'service',
+              scopes: ['read'],
+              rate_limit_rpm: 2,
+            },
+          ],
+        });
+      }
+
+      if (options.method === 'PATCH') {
+        return Promise.resolve({ ok: true, json: async () => ({}) });
+      }
+
+      return Promise.resolve({ ok: false, json: async () => [] });
+    });
+
+    const { validateBruceAuth } = require('../../shared/auth');
+
+    // Let the startup background token refresh resolve.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const req = { headers: { authorization: `Bearer ${rawToken}` } };
+    const first = validateBruceAuth(req);
+    const second = validateBruceAuth(req);
+    const third = validateBruceAuth(req);
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    expect(third).toEqual(
+      expect.objectContaining({ ok: false, status: 429 })
+    );
+    expect(third.error).toMatch(/Rate limit exceeded/);
+  });
+});

--- a/tests/unit/exec-security.test.js
+++ b/tests/unit/exec-security.test.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const { validateExecCommand } = require('../../shared/exec-security');
+
+describe('shared/exec-security validateExecCommand', () => {
+  test('allows commands matching whitelist', () => {
+    expect(validateExecCommand('docker ps')).toEqual({ allowed: true });
+    expect(validateExecCommand('curl -s https://example.com')).toEqual({ allowed: true });
+    expect(validateExecCommand('hostname')).toEqual({ allowed: true });
+  });
+
+  test('rejects commands matching blacklist', () => {
+    const result = validateExecCommand('docker ps && rm -rf /');
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/Blocked by blacklist/);
+  });
+
+  test('blacklist takes priority over whitelist', () => {
+    const result = validateExecCommand('curl -s https://example.com && reboot');
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/Blocked by blacklist/);
+  });
+});

--- a/tests/unit/helpers.test.js
+++ b/tests/unit/helpers.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const path = require('path');
+
+describe('shared/helpers', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    process.env.MANUAL_ROOT = '/manual-root';
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test('safeJoinManual blocks path traversal attempts', () => {
+    const { safeJoinManual } = require('../../shared/helpers');
+
+    expect(() => safeJoinManual('../../etc/passwd')).toThrow('Manual path escapes root directory');
+    expect(() => safeJoinManual('..\\..\\windows\\system32')).toThrow('Manual path escapes root directory');
+  });
+
+  test('safeJoinManual returns a path inside MANUAL_ROOT for safe relative paths', () => {
+    const { safeJoinManual } = require('../../shared/helpers');
+
+    const result = safeJoinManual('guides/getting-started.md');
+    expect(path.resolve(result).startsWith(path.resolve('/manual-root'))).toBe(true);
+    expect(result).toContain(path.join('guides', 'getting-started.md'));
+  });
+
+  test('bruceClampInt enforces min, max and default values', () => {
+    const { bruceClampInt } = require('../../shared/helpers');
+
+    expect(bruceClampInt('42', 10, 1, 100)).toBe(42);
+    expect(bruceClampInt('-5', 10, 1, 100)).toBe(1);
+    expect(bruceClampInt('1000', 10, 1, 100)).toBe(100);
+    expect(bruceClampInt('not-a-number', 10, 1, 100)).toBe(10);
+    expect(bruceClampInt(undefined, 10, 1, 100)).toBe(10);
+  });
+});


### PR DESCRIPTION
### Motivation
- Ajouter des tests unitaires pour améliorer la couverture et la sécurité des modules partagés `shared/auth.js`, `shared/helpers.js` et `shared/exec-security.js`.
- Vérifier l'extraction et la validation des tokens ainsi que le comportement du rate limiting sans dépendances réseau réelles.
- Vérifier les protections contre les path traversal et la validation des commandes exécutables.

### Description
- Ajout d'un `package.json` racine avec le script `"test": "jest"` et `jest` en `devDependencies` pour exécuter les tests via `npm test`.
- Ajout de tests unitaires `tests/unit/auth.test.js` couvrant l'extraction depuis `Authorization: Bearer ...`, l'extraction depuis `x-bruce-token`, le rejet quand le token est manquant ou invalide, et le comportement du rate limiting avec `fetch` mocké.
- Ajout de tests unitaires `tests/unit/helpers.test.js` couvrant `safeJoinManual` (protection contre path traversal et résolution correcte dans `MANUAL_ROOT`) et `bruceClampInt` (min, max, valeur par défaut).
- Ajout de tests unitaires `tests/unit/exec-security.test.js` couvrant `validateExecCommand` pour la whitelist, la blacklist et la priorité de la blacklist sur la whitelist.

### Testing
- Tentative d'installation des dépendances avec `npm install` a échoué à cause d'un blocage d'accès au registre npm (HTTP 403), donc les tests n'ont pas été exécutés.
- Tentative d'interroger la version de Jest avec `npx --yes jest --version` a échoué pour la même raison (HTTP 403), confirmant que les tests ne pouvaient pas être lancés dans cet environnement.
- Les fichiers de test et `package.json` ont été ajoutés et committés sur la branche `codex/add-unit-tests`, prêt pour exécution dans un environnement avec accès au registre npm.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c92be8a48327a17e86b53649cda0)