### PR TITLE
Add README.md for BRUCE MCP Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# BRUCE MCP Gateway
+
+BRUCE est une gateway HTTP construite avec Node.js et Express (`server.js`) qui centralise un grand nombre de routes sous le namespace `/bruce`. Elle sert de couche d'orchestration pour un assistant IA de homelab en exposant des endpoints liés au chat, à la mémoire, à l'infra, aux données et aux outils. Le dépôt inclut aussi une spécification OpenAPI intégrée intitulée "BRUCE MCP Gateway", ce qui positionne le service comme un serveur MCP/tool gateway. La documentation de sauvegarde fournie montre son usage dans un contexte Claude Desktop.
+
+## Structure du repository
+
+- `server.js` : point d'entrée Express (middlewares, montage des routes, OpenAPI, démarrage du serveur).
+- `routes/` : endpoints métier (ex. chat, mémoire, infra, RAG, fichiers, exécution, etc.).
+- `shared/` : modules partagés (config, auth, helpers, clients, orchestration LLM).
+- `tests/` : tests unitaires Jest (`tests/unit/*`).
+- Documents importants :
+  - `REVIEW.md`
+  - `REFACTOR_CHAT.md`
+  - `BACKUP_CLAUDE_DESKTOP.md`
+  - `.env.example`
+
+## Prérequis
+
+- Node.js 18+
+- Docker
+- Variables d'environnement configurées (voir `.env.example`)
+
+## Démarrage rapide
+
+```bash
+docker compose up -d
+```
+
+## Tests
+
+```bash
+npm test
+```
+
+(Test runner: Jest)


### PR DESCRIPTION
### Motivation
- Fournir un README racine décrivant le projet BRUCE comme une gateway Node.js/Express (MCP gateway) utilisée dans un contexte d'assistant IA homelab et référencer la documentation disponible (ex. BACKUP_CLAUDE_DESKTOP.md). 

### Description
- Ajout d'un fichier `README.md` à la racine contenant le titre "BRUCE MCP Gateway", une description concise (3–4 phrases), la structure du dépôt (`server.js`, `routes/`, `shared/`, `tests/` et documents importants), les prérequis (Node.js 18+, Docker, variables d'environnement via `.env.example`), la commande de démarrage rapide `docker compose up -d` et la commande de test `npm test` (Jest). 

### Testing
- Tentative d'exécution de `npm test` a échoué (`jest: not found`) et `npm install` a échoué ensuite avec une erreur `403 Forbidden` contre le registre npm dans cet environnement, empêchant l'installation de dépendances et la réussite des tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d1818fa08327b1cedd3c3f1099fb)