### PR TITLE
Add script to untrack files ignored by .gitignore

### DIFF
--- a/scripts/cleanup-ignored-files.sh
+++ b/scripts/cleanup-ignored-files.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script finds files that match already-configured .gitignore patterns but
+# are still tracked by Git, then removes them from the Git index only (keeps
+# files on disk) using `git rm --cached`.
+
+PATTERNS=(
+  "*.bak*"
+  "*.backup*"
+  "server_backup_*"
+  "sha256:*"
+  "*.snip"
+  "_patch_*/"
+  "_bak_*/"
+  "_scratch_*/"
+  "patch_ssh_keypref.py"
+)
+
+echo "Ignored/tracked candidates:"
+git ls-files --cached --ignored --exclude-standard -- "${PATTERNS[@]}"
+
+echo
+
+# Remove from Git tracking only (do not delete local files).
+git ls-files -z --cached --ignored --exclude-standard -- "${PATTERNS[@]}" \
+  | xargs -0 -r git rm --cached --


### PR DESCRIPTION
### Motivation
- Repository contains files that match existing `.gitignore` patterns but were tracked before the `.gitignore` existed, so a safe way to stop tracking them without deleting local files is needed.

### Description
- Add `scripts/cleanup-ignored-files.sh`, an executable shell script that lists tracked-but-ignored candidates for the patterns `*.bak*`, `*.backup*`, `server_backup_*`, `sha256:*`, `*.snip`, `_patch_*/`, `_bak_*/`, `_scratch_*/`, and `patch_ssh_keypref.py` with `git ls-files --cached --ignored --exclude-standard` and removes them from the index (not disk) with `git rm --cached`.

### Testing
- Verified the repository state and script syntax by running `git ls-files --cached --ignored --exclude-standard -- <patterns>` (no matches in this repo), `bash -n scripts/cleanup-ignored-files.sh` (syntax check OK), and `git status --short` after adding the file, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d18e031c8327b42301784bf51a0e)