### PR TITLE
docs(shared): add JSDoc comments for exported helper/auth/LLM utilities

### DIFF
--- a/shared/auth.js
+++ b/shared/auth.js
@@ -55,12 +55,11 @@ function checkRateLimit(tokenHash, rpm) {
 }
 
 /**
- * Validate auth + resolve scopes. SYNCHRONOUS — safe for all handlers.
- * Returns { ok, client_type?, scopes?, status?, error? }
- *
- * Usage:
- *   const auth = validateBruceAuth(req);           // basic auth check (backward compat)
- *   const auth = validateBruceAuth(req, 'docker');  // auth + scope check
+ * Validates the Bruce auth token from request headers and optionally enforces a required scope.
+ * Supports cached multi-token auth and a legacy single-token fallback.
+ * @param {import('express').Request} req - Incoming request containing auth headers.
+ * @param {string} [requiredScope] - Optional scope required for the authenticated token.
+ * @returns {{ ok: boolean, client_type?: string, scopes?: string[], status?: number, error?: string }} Authentication result payload.
  */
 function validateBruceAuth(req, requiredScope) {
   // ── Extract token from headers ──
@@ -111,8 +110,10 @@ function validateBruceAuth(req, requiredScope) {
 }
 
 /**
- * Express middleware factory: require scope on a route.
- * Usage: app.use('/bruce/docker', requireScope('docker'));
+ * Creates an Express middleware that requires a specific Bruce token scope.
+ * Attaches resolved auth metadata to req.bruceAuth when authorization succeeds.
+ * @param {string} scope - Scope required to access the protected route.
+ * @returns {(req: import('express').Request, res: import('express').Response, next: import('express').NextFunction) => void} Scope-checking middleware.
  */
 function requireScope(scope) {
   return (req, res, next) => {

--- a/shared/exec-security.js
+++ b/shared/exec-security.js
@@ -28,9 +28,9 @@ const BLACKLIST = [
 ];
 
 /**
- * Valide une commande exec.
- * @param {string} cmd - Commande à valider
- * @returns {{ allowed: boolean, reason?: string }}
+ * Validates whether an exec command is allowed using blacklist and whitelist rules.
+ * @param {string} cmd - Raw shell command to validate.
+ * @returns {{ allowed: boolean, reason?: string }} Validation result with an optional deny reason.
  */
 function validateExecCommand(cmd) {
   const trimmed = (cmd || '').trim();
@@ -54,7 +54,15 @@ function validateExecCommand(cmd) {
 }
 
 /**
- * Log audit entry to Supabase bruce_audit_log (fire-and-forget).
+ * Writes an exec audit entry to Supabase in fire-and-forget mode.
+ * Currently returns immediately because logging is disabled.
+ * @param {string} endpoint - API endpoint that triggered the exec action.
+ * @param {string} caller - Caller identity or client type.
+ * @param {string} host - Target host for the command execution context.
+ * @param {string} cmd - Executed command string.
+ * @param {string} result - Execution outcome label.
+ * @param {number} durationMs - Command duration in milliseconds.
+ * @returns {void} No return value.
  */
 function auditLog(endpoint, caller, host, cmd, result, durationMs) {
   // DISABLED: table bruce_audit_log inexistante/vidée, voir [840].

--- a/shared/fetch-utils.js
+++ b/shared/fetch-utils.js
@@ -1,6 +1,14 @@
 // shared/fetch-utils.js — [773] C7 REFONTE
 // fetchWithTimeout used by multiple route files
 
+/**
+ * Executes fetch with an AbortController timeout to prevent hanging requests.
+ * @param {string} url - Request URL to call.
+ * @param {RequestInit} [options] - Optional fetch configuration object.
+ * @param {number} timeoutMs - Timeout in milliseconds before aborting the request.
+ * @returns {Promise<Response>} Fetch response when the request succeeds before timeout.
+ * @throws {Error} Throws when fetch fails or the request is aborted on timeout.
+ */
 async function fetchWithTimeout(url, options, timeoutMs) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);

--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -8,19 +8,38 @@ const {
   BRUCE_FALLBACK_LOG_PATH,
 } = require('./config');
 
+/**
+ * Returns the current UTC timestamp formatted as an ISO 8601 string.
+ * @returns {string} Current date-time in ISO format.
+ */
 function utcNowIso() {
   return new Date().toISOString();
 }
 
+/**
+ * Removes <think>...</think> blocks from a model output string.
+ * @param {string} text - Raw text that may include think blocks.
+ * @returns {string} Sanitized text without think blocks.
+ */
 function stripThinkBlock(text) {
   const t = String(text || '');
   return t.replace(/<think>[\s\S]*?<\/think>\s*/g, '').trim();
 }
 
+/**
+ * Indicates whether Supabase URL and service key are configured.
+ * @returns {boolean} True when both SUPABASE_URL and SUPABASE_KEY are present.
+ */
 function isSupabaseConfigured() {
   return Boolean(SUPABASE_URL && SUPABASE_KEY);
 }
 
+/**
+ * Appends a single line to a target file, logging write errors to stderr.
+ * @param {string} pathToFile - Absolute or relative file path to append to.
+ * @param {string} text - Content line to append without newline suffix.
+ * @returns {void} No return value.
+ */
 function appendLineToFile(pathToFile, text) {
   try {
     fs.appendFile(pathToFile, text + '\n', (err) => {
@@ -33,17 +52,36 @@ function appendLineToFile(pathToFile, text) {
   }
 }
 
+/**
+ * Serializes and appends a fallback log record to the configured fallback log file.
+ * @param {Record<string, any>} record - Structured record to persist in the fallback log.
+ * @returns {Promise<void>} Resolves when the append operation is scheduled.
+ */
 async function logFallback(record) {
   const line = JSON.stringify(record, null, 0);
   appendLineToFile(BRUCE_FALLBACK_LOG_PATH, line);
 }
 
+/**
+ * Parses and clamps an integer value between provided minimum and maximum bounds.
+ * @param {unknown} v - Raw value to parse as integer.
+ * @param {number} defVal - Default value used when parsing fails.
+ * @param {number} minVal - Inclusive lower bound.
+ * @param {number} maxVal - Inclusive upper bound.
+ * @returns {number} Parsed and clamped integer result.
+ */
 function bruceClampInt(v, defVal, minVal, maxVal) {
   const n = parseInt(String(v || ''), 10);
   if (!isFinite(n)) return defVal;
   return Math.max(minVal, Math.min(maxVal, n));
 }
 
+/**
+ * Resolves a manual-relative path safely under MANUAL_ROOT and blocks path traversal.
+ * @param {string} relativePath - Relative manual path requested by the caller.
+ * @returns {string} Joined absolute path rooted under MANUAL_ROOT.
+ * @throws {Error} Throws when the provided path is invalid or escapes MANUAL_ROOT.
+ */
 function safeJoinManual(relativePath) {
   if (!relativePath || typeof relativePath !== 'string') {
     throw new Error('Invalid manual path');
@@ -61,6 +99,11 @@ function safeJoinManual(relativePath) {
   return fullPath;
 }
 
+/**
+ * Recursively lists Markdown files under a base directory as relative POSIX-style paths.
+ * @param {string} baseDir - Root directory to crawl for markdown files.
+ * @returns {string[]} Relative .md file paths discovered in the directory tree.
+ */
 function listMarkdownFiles(baseDir) {
   const results = [];
 
@@ -87,6 +130,11 @@ function listMarkdownFiles(baseDir) {
   return results;
 }
 
+/**
+ * Performs a lightweight health check against a URL with timeout handling.
+ * @param {string} url - Endpoint URL to ping.
+ * @returns {Promise<{status: 'planned'|'ok'|'offline', httpStatus: number|null, error: string|null}>} Connectivity status payload.
+ */
 async function pingUrl(url) {
   if (!url) {
     return { status: 'planned', httpStatus: null, error: 'no url configured' };

--- a/shared/llm-queue.js
+++ b/shared/llm-queue.js
@@ -12,6 +12,10 @@ const { stripThinkBlock } = require('./helpers');
 let llmInFlight = 0;
 const llmQueue = [];
 
+/**
+ * Acquires a concurrency slot for an LLM call, queueing when capacity is reached.
+ * @returns {Promise<void>} Resolves when execution is allowed to proceed.
+ */
 function acquireLlmSlot() {
   if (llmInFlight < BRUCE_MAX_CONCURRENT) {
     llmInFlight += 1;
@@ -23,6 +27,10 @@ function acquireLlmSlot() {
   });
 }
 
+/**
+ * Releases a previously acquired LLM concurrency slot and wakes the next waiter.
+ * @returns {void} No return value.
+ */
 function releaseLlmSlot() {
   llmInFlight = Math.max(0, llmInFlight - 1);
   if (llmQueue.length > 0 && llmInFlight < BRUCE_MAX_CONCURRENT) {
@@ -34,6 +42,12 @@ function releaseLlmSlot() {
   }
 }
 
+/**
+ * Sends a chat completion request to the configured LLM backend with queue-based throttling.
+ * @param {{role: string, content: string}[]} messages - Conversation messages for the completion request.
+ * @returns {Promise<{role: string, content: string}>} Assistant message normalized from backend response.
+ * @throws {Error} Throws when LLM settings are missing or the backend response is invalid.
+ */
 async function callLlm(messages) {
   if (!BRUCE_LLM_API_BASE || !BRUCE_LLM_MODEL) {
     throw new Error('BRUCE_LLM_API_BASE or BRUCE_LLM_MODEL not configured');


### PR DESCRIPTION
### Motivation
- Ajouter une documentation JSDoc claire sur les fonctions exportées des modules partagés pour améliorer la lisibilité et l'auto-complétion sans modifier la logique d'exécution.
- Cibler les utilitaires d'auth, d'aide, d'exécution sécurisée, de fetch timeout et la queue LLM afin de documenter les paramètres, retours et exceptions attendues.

### Description
- Ajout de JSDoc à `validateBruceAuth` et `requireScope` dans `shared/auth.js` avec `@param` et `@returns` décrivant le payload de retour.
- Ajout de JSDoc sur toutes les fonctions exportées de `shared/helpers.js` (`utcNowIso`, `stripThinkBlock`, `isSupabaseConfigured`, `appendLineToFile`, `logFallback`, `bruceClampInt`, `safeJoinManual`, `listMarkdownFiles`, `pingUrl`) incluant un `@throws` pour `safeJoinManual`.
- Mise à jour des blocs JSDoc pour `validateExecCommand` et `auditLog` dans `shared/exec-security.js` et ajout de javadoc pour `fetchWithTimeout` dans `shared/fetch-utils.js`.
- Ajout de JSDoc pour `acquireLlmSlot`, `releaseLlmSlot` et `callLlm` dans `shared/llm-queue.js` avec `@throws` pour les erreurs LLM.

### Testing
- Exécuté `node --check` sur `shared/auth.js`, `shared/helpers.js`, `shared/exec-security.js`, `shared/fetch-utils.js` et `shared/llm-queue.js`, et toutes les vérifications ont réussi.
- Aucune modification de logique n'a été effectuée, seules des annotations JSDoc ont été ajoutées, donc les tests statiques suffisent pour valider la PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d196c70c8327843e8fe37dfc60bb)