### PR TITLE
Add integration tests for critical gateway routes (auth / exec / write)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "jest"
   },
   "devDependencies": {
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "supertest": "^7.1.1"
   }
 }

--- a/tests/integration/auth.integration.test.js
+++ b/tests/integration/auth.integration.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const request = require('supertest');
+const express = require('express');
+
+function buildInfraApp(fetchImpl) {
+  jest.resetModules();
+  jest.doMock('../../shared/fetch-utils', () => ({
+    fetchWithTimeout: jest.fn(fetchImpl),
+  }));
+
+  const router = require('../../routes/infra');
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  return app;
+}
+
+describe('Integration - auth on /bruce/integrity', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      BRUCE_AUTH_TOKEN: 'good-token',
+      SUPABASE_URL: 'http://supabase.local',
+      SUPABASE_KEY: 'service-key',
+      BRUCE_LLM_API_KEY: 'llm-key',
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.dontMock('../../shared/fetch-utils');
+    jest.clearAllMocks();
+  });
+
+  test('GET /bruce/integrity sans token → 401', async () => {
+    const app = buildInfraApp(async () => ({ ok: true, status: 200, json: async () => ({ ok: true }) }));
+
+    const res = await request(app).get('/bruce/integrity');
+
+    expect(res.status).toBe(401);
+    expect(res.body.ok).toBe(false);
+  });
+
+  test('GET /bruce/integrity avec mauvais token → 401', async () => {
+    const app = buildInfraApp(async () => ({ ok: true, status: 200, json: async () => ({ ok: true }) }));
+
+    const res = await request(app)
+      .get('/bruce/integrity')
+      .set('Authorization', 'Bearer wrong-token');
+
+    expect(res.status).toBe(401);
+    expect(res.body.ok).toBe(false);
+  });
+
+  test('GET /bruce/integrity avec bon token → 200 (logique interne mockée)', async () => {
+    const app = buildInfraApp(async (url) => {
+      const u = String(url);
+      if (u.includes('/v_bruce_dashboard')) {
+        return { ok: true, status: 200, json: async () => [{ id: 1 }] };
+      }
+      if (u.includes('/staging_queue?status=eq.pending')) {
+        return { ok: true, status: 200, json: async () => [] };
+      }
+      if (u.includes('/rpc/check_sequences')) {
+        return { ok: true, status: 200, json: async () => [{ status: 'OK' }] };
+      }
+      if (u.includes('/health')) {
+        return { ok: true, status: 200, json: async () => ({ ok: true }) };
+      }
+      return { ok: true, status: 200, json: async () => ({}) };
+    });
+
+    const res = await request(app)
+      .get('/bruce/integrity')
+      .set('Authorization', 'Bearer good-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({ ok: true }));
+    expect(res.body.checks).toBeDefined();
+  });
+});

--- a/tests/integration/data-write.integration.test.js
+++ b/tests/integration/data-write.integration.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const request = require('supertest');
+const express = require('express');
+
+function buildDataWriteApp() {
+  jest.resetModules();
+  jest.doMock('../../shared/fetch-utils', () => ({
+    fetchWithTimeout: jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => [{ id: 123 }],
+      text: async () => '',
+    })),
+  }));
+
+  const router = require('../../routes/data-write');
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  return app;
+}
+
+describe('Integration - /bruce/write', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      BRUCE_AUTH_TOKEN: 'good-token',
+      SUPABASE_URL: 'http://supabase.local',
+      SUPABASE_KEY: 'service-key',
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.dontMock('../../shared/fetch-utils');
+    jest.clearAllMocks();
+  });
+
+  test('POST /bruce/write sans token → 401', async () => {
+    const app = buildDataWriteApp();
+
+    const res = await request(app).post('/bruce/write').send({});
+
+    expect(res.status).toBe(401);
+    expect(res.body.ok).toBe(false);
+  });
+
+  test('POST /bruce/write avec body incomplet → 400', async () => {
+    const app = buildDataWriteApp();
+
+    const res = await request(app)
+      .post('/bruce/write')
+      .set('Authorization', 'Bearer good-token')
+      .send({ table_cible: 'lessons_learned' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+});

--- a/tests/integration/exec.integration.test.js
+++ b/tests/integration/exec.integration.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const request = require('supertest');
+const express = require('express');
+
+function buildExecApp() {
+  jest.resetModules();
+  const router = require('../../routes/exec');
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  return app;
+}
+
+describe('Integration - /bruce/exec', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      BRUCE_AUTH_TOKEN: 'good-token',
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.clearAllMocks();
+  });
+
+  test('POST /bruce/exec sans token → 401', async () => {
+    const app = buildExecApp();
+
+    const res = await request(app).post('/bruce/exec').send({ command: 'hostname' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBeTruthy();
+  });
+
+  test('POST /bruce/exec avec commande non whitelistée → 400/403', async () => {
+    const app = buildExecApp();
+
+    const res = await request(app)
+      .post('/bruce/exec')
+      .set('Authorization', 'Bearer good-token')
+      .send({ command: 'rm -rf /tmp/test' });
+
+    expect([400, 403]).toContain(res.status);
+    expect(res.body.ok).toBe(false);
+  });
+
+  test('POST /bruce/exec sans champ command → 400', async () => {
+    const app = buildExecApp();
+
+    const res = await request(app)
+      .post('/bruce/exec')
+      .set('Authorization', 'Bearer good-token')
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Add integration coverage for the gateway's most critical routes to ensure auth, input validation and exec security behaviors are protected. 
- Keep tests isolated from external services by mocking networked dependencies so CI can validate route logic without Supabase/LLM/Docker. 

### Description
- Add `supertest` to `devDependencies` in `package.json` to enable HTTP integration tests with `jest`. 
- Add `tests/integration/auth.integration.test.js` which covers `GET /bruce/integrity` for missing token (`401`), invalid token (`401`) and valid token (`200`) with internal checks mocked via a `fetchWithTimeout` stub. 
- Add `tests/integration/exec.integration.test.js` which covers `POST /bruce/exec` for missing token (`401`), a non-whitelisted command (`400`/`403`) and missing `command` field (`400`). 
- Add `tests/integration/data-write.integration.test.js` which covers `POST /bruce/write` for missing token (`401`) and incomplete body (`400`), and mocks `fetchWithTimeout` for Supabase interactions. 

### Testing
- Attempted to install node dependencies with `npm install`, but the environment rejected registry access (`403 Forbidden`) so dependency installation failed. 
- Attempted to run the new integration tests with `npm test -- --runInBand ...`, but `jest` was unavailable in the container (error: `jest: not found`) because install failed. 
- No automated tests were executed successfully in this environment due to the registry access issue; test files and dependency additions are in place and will run once dependencies can be installed in CI or a developer environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d19d60c083279837997c0686f195)