### PR TITLE
Log silent catch blocks in routes to surface swallowed errors

### DIFF
--- a/routes/ask.js
+++ b/routes/ask.js
@@ -36,7 +36,7 @@ router.post('/bruce/ask', async (req, res) => {
         const histData = await histRes.json();
         conversationHistory = histData.reverse().map(m => ({ role: m.role, content: m.content }));
       }
-    } catch(e) { /* historique non critique */ }
+    } catch(e) { console.error('[ask.js][/bruce/ask] erreur silencieuse:', e.message || e); }
   }
 
   // 1. RAG: chercher contexte pertinent
@@ -127,7 +127,7 @@ Reponds de facon concise et actionnable.`;
             body: JSON.stringify(msgs) },
           5000
         );
-      } catch(e) { /* non critique */ }
+      } catch(e) { console.error('[ask.js][/bruce/ask] erreur silencieuse:', e.message || e); }
     }
 
     return res.json({

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -522,7 +522,8 @@ function parseLegacyToolCallFromContent(content) {
     const name = obj && obj.name ? String(obj.name) : null;
     const args = obj && obj.arguments && typeof obj.arguments === "object" ? obj.arguments : {};
     return name ? { name, arguments: args } : null;
-  } catch (_) {
+  } catch (e) {
+    console.error('[chat.js][/bruce/agent/chat] erreur silencieuse:', e.message || e);
     return null;
   }
 }
@@ -569,7 +570,7 @@ async function sshExecViaNodeSsh(host, command, timeoutMs) {
     // BRUCE: prefer key auth; fallback to password
     const keyPath = "/home/furycom/bruce-config/bruce_gateway_ed25519";
     let privateKey = null;
-    try { privateKey = fs.readFileSync(keyPath, "utf8"); } catch (_) {}
+    try { privateKey = fs.readFileSync(keyPath, "utf8"); } catch (e) { console.error('[chat.js][/bruce/agent/chat] erreur silencieuse:', e.message || e); }
 
     if (privateKey) {
       try {
@@ -609,7 +610,7 @@ const r = await ssh.execCommand(String(command), { execOptions: { pty: false } }
   } finally {
     try {
       ssh.dispose();
-    } catch (_) {}
+    } catch (e) { console.error('[chat.js][/bruce/agent/chat] erreur silencieuse:', e.message || e); }
   }
 }
 
@@ -765,7 +766,7 @@ async function executeTool(toolName, params) {
       } catch (err) {
         return { error: String(err && err.message ? err.message : err) };
       } finally {
-        try { db.close(); } catch (_) {}
+        try { db.close(); } catch (e) { console.error('[chat.js][/bruce/agent/chat] erreur silencieuse:', e.message || e); }
       }
     }
 
@@ -871,7 +872,7 @@ async function executeTool(toolName, params) {
       } catch (error) {
         try {
           await sshExecViaNodeSsh(host, "rm '" + tempScript + "' 2>/dev/null || true", 5000);
-        } catch (e) {}
+        } catch (e) { console.error('[chat.js][/bruce/agent/chat] erreur silencieuse:', e.message || e); }
         
         return {
           success: false,
@@ -925,7 +926,7 @@ router.post("/bruce/agent/chat", async (req, res) => {
         if (rows && rows[0] && Object.prototype.hasOwnProperty.call(rows[0], "count")) {
           n = rows[0].count;
         }
-      } catch (_) {}
+      } catch (e) { console.error('[chat.js][/bruce/agent/chat] erreur silencieuse:', e.message || e); }
       const response = (n === null)
         ? (toolRes && toolRes.output ? toolRes.output : JSON.stringify(toolRes))
         : String(n);
@@ -936,7 +937,7 @@ router.post("/bruce/agent/chat", async (req, res) => {
       });
     }
   } catch (err) {
-    // fall through
+    console.error('[chat.js][/bruce/agent/chat] erreur silencieuse:', err.message || err);
   }
 
 

--- a/routes/data-write.js
+++ b/routes/data-write.js
@@ -91,7 +91,7 @@ router.post('/bruce/write', async (req, res) => {
         const stgEntry = Array.isArray(stgData) ? stgData[0] : stgData;
         if (stgEntry?.rejection_reason) rejectionReason = stgEntry.rejection_reason;
         if (stgEntry?.status === 'rejected' && !rejectionReason) rejectionReason = 'Rejected by validate.py (no reason captured)';
-      } catch(re) { /* ignore fetch error */ }
+      } catch(re) { console.error('[data-write.js][/bruce/data/write] erreur silencieuse:', re.message || re); }
     }
 
     const response = {

--- a/routes/inbox.js
+++ b/routes/inbox.js
@@ -106,7 +106,7 @@ router.post('/bruce/archive/ingest', async (req, res) => {
           const ok = code === 0 || stdout.includes('TERMIN') || stdout.includes('staging');
           if (ok) {
             const dest = `${SENT_DIR}/${file}`;
-            try { fs.renameSync(filePath, dest); } catch(e) {}
+            try { fs.renameSync(filePath, dest); } catch(e) { console.error('[inbox.js][/bruce/archive/ingest] erreur silencieuse:', e.message || e); }
           }
           results.push({ file, ok, code, output: stdout.slice(0, 500) });
           resolve();

--- a/routes/infra.js
+++ b/routes/infra.js
@@ -452,7 +452,9 @@ router.get('/bruce/llm/status', async (req, res) => {
         }
       }
     }
-  } catch (_) {}
+  } catch (e) {
+    console.error('[infra.js][/bruce/llm/status] erreur silencieuse:', e.message || e);
+  }
 
   // 3. Get model name from /props
   try {
@@ -464,7 +466,9 @@ router.get('/bruce/llm/status', async (req, res) => {
       const props = await propsResp.json();
       result.llama_server.model = props.default_generation_settings?.model || null;
     }
-  } catch (_) {}
+  } catch (e) {
+    console.error('[infra.js][/bruce/llm/status] erreur silencieuse:', e.message || e);
+  }
 
   // 4. Check LiteLLM
   try {
@@ -484,7 +488,9 @@ router.get('/bruce/llm/status', async (req, res) => {
       result.dspy_job.running = true;
       result.dspy_job.progress = prog;
     }
-  } catch (_) {}
+  } catch (e) {
+    console.error('[infra.js][/bruce/llm/status] erreur silencieuse:', e.message || e);
+  }
 
   result.elapsed_ms = Date.now() - startMs;
   res.json(result);

--- a/routes/rag.js
+++ b/routes/rag.js
@@ -650,7 +650,7 @@ router.post('/bruce/preflight', async (req, res) => {
         for (const r of (ragResult.results || [])) {
           const chunk = chunkMap[r.chunk_id] || {};
           let anchor = {};
-          try { anchor = typeof chunk.anchor === 'string' ? JSON.parse(chunk.anchor) : (chunk.anchor || {}); } catch(_) {}
+          try { anchor = typeof chunk.anchor === 'string' ? JSON.parse(chunk.anchor) : (chunk.anchor || {}); } catch(e) { console.error('[rag.js][/bruce/preflight] erreur silencieuse:', e.message || e); }
           if (anchor.source !== 'lessons_learned') continue;
           const imp = anchor.importance || '';
           if (imp !== 'critical' && imp !== 'high') continue;
@@ -689,7 +689,7 @@ router.post('/bruce/preflight', async (req, res) => {
         );
         const kbArr = await kbRes.json();
         if (Array.isArray(kbArr)) runbooks.push(...kbArr);
-      } catch(e) { /* optionnel */ }
+      } catch(e) { console.error('[rag.js][/bruce/preflight] erreur silencieuse:', e.message || e); }
     }
     // Dédupliquer runbooks par id
     const seenIds = new Set();

--- a/routes/session.js
+++ b/routes/session.js
@@ -87,7 +87,7 @@ router.post('/bruce/session/init', async (req, res) => {
         newSessionId = createData.id;
       }
     } catch (sessErr) {
-      // Non-blocking: session creation failure doesn't break init
+      console.error('[session.js][/bruce/session/init] erreur silencieuse:', sessErr.message || sessErr);
     }
 
     // -- 2. RAG semantique multi-query [90+91] --
@@ -150,7 +150,7 @@ router.post('/bruce/session/init', async (req, res) => {
           preview: (r.preview || '').slice(0, 200)
         }));
     } catch (ragErr) {
-      // RAG optionnel - ne bloque pas
+      console.error('[session.js][/bruce/session/init] erreur silencieuse:', ragErr.message || ragErr);
     }
 
     // [719] CONTEXT ROUTER v2: FTS + semantique hybride en parallele
@@ -201,7 +201,7 @@ router.post('/bruce/session/init', async (req, res) => {
               validSemIds.forEach(s => { scoreMap[s.id] = s.score; });
               semLessons = semRaw.map(l => ({ ...l, _sem_score: scoreMap[l.id] || 0.5 }));
             }
-          } catch (_) {}
+          } catch (e) { console.error('[session.js][/bruce/session/init] erreur silencieuse:', e.message || e); }
         }
 
         // Fusionner FTS + semantique avec score composite
@@ -265,7 +265,7 @@ router.post('/bruce/session/init', async (req, res) => {
         userProfileContext = '\n\n**PROFIL UTILISATEUR YANN (injection [877]):**\n'
           + profiles.map(p => p.answer.slice(0, 600)).join('\n');
       }
-    } catch (e) { /* non-bloquant */ }
+    } catch (e) { console.error('[session.js][/bruce/session/init] erreur silencieuse:', e.message || e); }
 
     let llmSummary = null;
     let llmOk = false;
@@ -482,7 +482,7 @@ router.get('/bruce/session/close/checklist', async (req, res) => {
       const data = await r.json();
       sessionInfo = Array.isArray(data) && data[0] ? data[0] : null;
     } catch (e) {
-      // pas bloquant
+      console.error('[session.js][/bruce/session/close/checklist] erreur silencieuse:', e.message || e);
     }
 
     // ── 2. Récupérer les lessons créées pendant cette session ──
@@ -493,7 +493,7 @@ router.get('/bruce/session/close/checklist', async (req, res) => {
         { headers: hSupa }, 8000
       );
       sessionLessons = await r.json();
-    } catch (e) {}
+    } catch (e) { console.error('[session.js][/bruce/session/close/checklist] erreur silencieuse:', e.message || e); }
 
     // ── 3. Récupérer les tâches roadmap modifiées (doing/done récentes) ──
     let recentTasks = [];
@@ -503,7 +503,7 @@ router.get('/bruce/session/close/checklist', async (req, res) => {
         { headers: hSupa }, 8000
       );
       recentTasks = await r.json();
-    } catch (e) {}
+    } catch (e) { console.error('[session.js][/bruce/session/close/checklist] erreur silencieuse:', e.message || e); }
 
     // ── 4. Récupérer le staging pending (devrait être 0 avant clôture) ──
     let stagingPending = 0;
@@ -514,7 +514,7 @@ router.get('/bruce/session/close/checklist', async (req, res) => {
       );
       const data = await r.json();
       stagingPending = Array.isArray(data) ? data.length : 0;
-    } catch (e) {}
+    } catch (e) { console.error('[session.js][/bruce/session/close/checklist] erreur silencieuse:', e.message || e); }
 
     // ── 5. Récupérer CURRENT_STATE handoff_vivant ──
     let currentHandoff = '';
@@ -525,7 +525,7 @@ router.get('/bruce/session/close/checklist', async (req, res) => {
       );
       const data = await r.json();
       currentHandoff = Array.isArray(data) && data[0] ? data[0].value : '';
-    } catch (e) {}
+    } catch (e) { console.error('[session.js][/bruce/session/close/checklist] erreur silencieuse:', e.message || e); }
 
     // ── 6. Construire la checklist avec avertissements ──
     const warnings = [];
@@ -560,7 +560,7 @@ router.get('/bruce/session/close/checklist', async (req, res) => {
         const uncommitted = gitOut.trim().split('\n').length;
         warnings.push('[876] WARNING: ' + uncommitted + ' fichier(s) non commite(s) dans mcp-stack. Git commit recommande avant fermeture.');
       }
-    } catch (e) { /* git check optionnel */ }
+    } catch (e) { console.error('[session.js][/bruce/session/close/checklist] erreur silencieuse:', e.message || e); }
 
     if (stagingPending > 0) {
       warnings.push(`⚠️ ${stagingPending} items en staging pending — valider AVANT de clôturer.`);

--- a/routes/tools-unlock.js
+++ b/routes/tools-unlock.js
@@ -37,7 +37,7 @@ router.all('/bruce/tools/unlocked', async (req, res) => {
         try {
           const r = await fetchWithTimeout(c.url, { method: 'GET' }, 3000);
           if (r.ok) caps.push(...c.caps);
-        } catch (_) {}
+        } catch (e) { console.error('[tools-unlock.js][/bruce/tools/unlocked] erreur silencieuse:', e.message || e); }
       }));
       if (caps.includes('embedder_bge_m3') && caps.includes('supabase_operationnel')) {
         caps.push('indexation_auto_chunks');


### PR DESCRIPTION
### Motivation
- Rendre visibles les erreurs silencieusement swallowées dans les handlers HTTP en ajoutant un log minimal sans modifier la logique existante.

### Description
- Ajout d'un `console.error('[<file>][<endpoint>] erreur silencieuse:', e.message || e)` dans les `catch` vides/comment-only/`return`-only pour s'assurer que les exceptions sont signalées tout en conservant les comportements/fallbacks actuels.
- Fichiers modifiés : `routes/infra.js`, `routes/rag.js`, `routes/session.js`, `routes/inbox.js`, `routes/chat.js`, `routes/tools-unlock.js`, `routes/ask.js`, `routes/data-write.js`.
- Le format de log utilisé est exactement : `console.error('[route][endpoint] erreur silencieuse:', e.message || e)` et les emplacements tests/fallbacks existants ont été laissés intacts.

### Testing
- Recherche et vérification automatique des `catch` vides / commentaire-seul / `return`-only exécutée via `rg` et petits scripts Python, confirmant que les patterns ciblés ont été traités (aucun `catch` vide/comment-only/return-only restant pour `routes/*.js`).
- Tentative d'exécution de la suit de tests via `npm test -- --runInBand`, qui a échoué car `jest` n'est pas installé dans l'environnement local (`jest: not found`).
- Aucun changement fonctionnel introduit; seuls des `console.error` ont été ajoutés pour améliorer la visibilité des erreurs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d1a2a6c083279161ef3082b749c9)