### PR TITLE
Refactor OpenAPI spec: centralize JSON schema, standardize responses, and add endpoint definitions

### DIFF
--- a/server.js
+++ b/server.js
@@ -143,6 +143,8 @@ sessionRoutes.setSafePythonSpawn(safePythonSpawn);
 
 // ========== HEALTH ==========
 
+const jsonObjectSchema = { type: "object", additionalProperties: true };
+
 // --- OpenAPI spec for OpenWebUI Tool Server (VB1) ---
 const BRUCE_OPENAPI_SPEC = {
   openapi: "3.0.3",
@@ -182,7 +184,7 @@ const BRUCE_OPENAPI_SPEC = {
             description: "OK",
             content: {
               "application/json": {
-                schema: { type: "object", additionalProperties: true }
+                schema: jsonObjectSchema
               }
             }
           }
@@ -197,7 +199,7 @@ const BRUCE_OPENAPI_SPEC = {
             description: "OK",
             content: {
               "application/json": {
-                schema: { type: "object", additionalProperties: true }
+                schema: jsonObjectSchema
               }
             }
           }
@@ -220,7 +222,7 @@ const BRUCE_OPENAPI_SPEC = {
             description: "OK",
             content: {
               "application/json": {
-                schema: { type: "object", additionalProperties: true }
+                schema: jsonObjectSchema
               }
             }
           }
@@ -237,7 +239,7 @@ const BRUCE_OPENAPI_SPEC = {
               description: "OK",
               content: {
                 "application/json": {
-                  schema: { type: "object", additionalProperties: true }
+                  schema: jsonObjectSchema
                 }
               }
             }
@@ -253,7 +255,7 @@ const BRUCE_OPENAPI_SPEC = {
                 description: "OK",
                 content: {
                   "application/json": {
-                    schema: { type: "object", additionalProperties: true }
+                    schema: jsonObjectSchema
                   }
                 }
               }
@@ -268,7 +270,7 @@ const BRUCE_OPENAPI_SPEC = {
               required: true,
               content: {
                 "application/json": {
-                  schema: { type: "object", additionalProperties: true }
+                  schema: jsonObjectSchema
                 }
               }
             },
@@ -277,7 +279,7 @@ const BRUCE_OPENAPI_SPEC = {
                 description: "OK",
                 content: {
                   "application/json": {
-                    schema: { type: "object", additionalProperties: true }
+                    schema: jsonObjectSchema
                   }
                 }
               }
@@ -293,7 +295,7 @@ const BRUCE_OPENAPI_SPEC = {
               description: "OK",
               content: {
                 "application/json": {
-                  schema: { type: "object", additionalProperties: true }
+                  schema: jsonObjectSchema
                 }
               }
             }
@@ -324,7 +326,7 @@ const BRUCE_OPENAPI_SPEC = {
               description: "OK",
               content: {
                 "application/json": {
-                  schema: { type: "object", additionalProperties: true }
+                  schema: jsonObjectSchema
                 }
               }
             }
@@ -355,7 +357,7 @@ const BRUCE_OPENAPI_SPEC = {
               description: "OK",
               content: {
                 "application/json": {
-                  schema: { type: "object", additionalProperties: true }
+                  schema: jsonObjectSchema
                 }
               }
             }
@@ -366,31 +368,363 @@ const BRUCE_OPENAPI_SPEC = {
 };
 
 
-// --- PATCH: OpenAPI expose /bruce/agent/chat ---
-BRUCE_OPENAPI_SPEC.paths["/bruce/agent/chat"] = {
-  post: {
-    summary: "BRUCE Agent chat",
-    requestBody: {
-      required: true,
-      content: {
-        "application/json": {
-          schema: { type: "object", additionalProperties: true }
-        }
+const makeStandardResponses = () => ({
+  "200": {
+    description: "OK",
+    content: {
+      "application/json": {
+        schema: jsonObjectSchema
       }
-    },
-    responses: {
-      "200": {
-        description: "OK",
-        content: {
-          "application/json": {
-            schema: { type: "object", additionalProperties: true }
-          }
-        }
+    }
+  },
+  "400": {
+    description: "Bad request",
+    content: {
+      "application/json": {
+        schema: jsonObjectSchema
+      }
+    }
+  },
+  "401": {
+    description: "Unauthorized",
+    content: {
+      "application/json": {
+        schema: jsonObjectSchema
+      }
+    }
+  },
+  "500": {
+    description: "Internal server error",
+    content: {
+      "application/json": {
+        schema: jsonObjectSchema
       }
     }
   }
-};
-// --- /PATCH ---
+});
+
+Object.assign(BRUCE_OPENAPI_SPEC.paths, {
+  "/admin": {
+    get: { operationId: "admin_ui", summary: "Serve admin dashboard placeholder page", responses: makeStandardResponses() }
+  },
+  "/connectors": {
+    get: { operationId: "connectors_list", summary: "List configured connectors and statuses", responses: makeStandardResponses() }
+  },
+  "/manual/pages": {
+    get: { operationId: "manual_pages", summary: "List available manual markdown pages", responses: makeStandardResponses() }
+  },
+  "/manual/page": {
+    get: { operationId: "manual_page", summary: "Read one manual markdown page by path", responses: makeStandardResponses() }
+  },
+  "/manual/search": {
+    get: { operationId: "manual_search", summary: "Search text across manual pages", responses: makeStandardResponses() }
+  },
+  "/tools": {
+    get: { operationId: "tools_list", summary: "List available tools metadata", responses: makeStandardResponses() }
+  },
+  "/tools/echo": {
+    post: {
+      operationId: "tools_echo",
+      summary: "Echo provided payload for diagnostics",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", additionalProperties: true } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/tools/supabase/exec-sql": {
+    post: {
+      operationId: "tools_supabase_exec_sql",
+      summary: "Execute a SQL statement against Supabase",
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: { type: "object", required: ["sql"], properties: { sql: { type: "string" } } }
+          }
+        }
+      },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/browser/fetch": {
+    post: {
+      operationId: "bruce_browser_fetch",
+      summary: "Fetch remote page HTML via browser helper",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", required: ["url"], properties: { url: { type: "string" } } } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/browser/screenshot": {
+    post: {
+      operationId: "bruce_browser_screenshot",
+      summary: "Capture a screenshot of a remote page",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", required: ["url"], properties: { url: { type: "string" } } } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/browser/scrape": {
+    post: {
+      operationId: "bruce_browser_scrape",
+      summary: "Scrape structured content from a remote page",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", required: ["url"], properties: { url: { type: "string" } } } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/chatgpt": {
+    post: {
+      operationId: "bruce_chatgpt",
+      summary: "Proxy a ChatGPT-style completion request",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", additionalProperties: true } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/read": {
+    post: {
+      operationId: "bruce_read",
+      summary: "Read data from configured backend resources",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", additionalProperties: true } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/roadmap/list": {
+    get: { operationId: "bruce_roadmap_list", summary: "List roadmap tasks and their statuses", responses: makeStandardResponses() }
+  },
+  "/bruce/write": {
+    post: {
+      operationId: "bruce_write",
+      summary: "Write data to configured backend resources",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", additionalProperties: true } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/docker/ps": {
+    get: { operationId: "bruce_docker_ps", summary: "List running Docker containers", responses: makeStandardResponses() }
+  },
+  "/bruce/docker/inspect/{container}": {
+    get: { operationId: "bruce_docker_inspect", summary: "Inspect one Docker container", responses: makeStandardResponses() }
+  },
+  "/bruce/docker/logs/{container}": {
+    get: { operationId: "bruce_docker_logs", summary: "Read recent logs from one Docker container", responses: makeStandardResponses() }
+  },
+  "/bruce/docker/stats/{container}": {
+    get: { operationId: "bruce_docker_stats", summary: "Read runtime stats from one Docker container", responses: makeStandardResponses() }
+  },
+  "/bruce/docker/restart/{container}": {
+    post: { operationId: "bruce_docker_restart", summary: "Restart one Docker container", responses: makeStandardResponses() }
+  },
+  "/bruce/docker/stop/{container}": {
+    post: { operationId: "bruce_docker_stop", summary: "Stop one Docker container", responses: makeStandardResponses() }
+  },
+  "/bruce/docker/start/{container}": {
+    post: { operationId: "bruce_docker_start", summary: "Start one Docker container", responses: makeStandardResponses() }
+  },
+  "/bruce/docker/health": {
+    get: { operationId: "bruce_docker_health", summary: "Get aggregated Docker health status", responses: makeStandardResponses() }
+  },
+  "/bruce/exec": {
+    post: {
+      operationId: "bruce_exec",
+      summary: "Execute a command with gateway execution guardrails",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", required: ["cmd"], properties: { cmd: { type: "string" } } } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/file/write": {
+    post: {
+      operationId: "bruce_file_write",
+      summary: "Write text content to an allowed file path",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", required: ["path", "content"], properties: { path: { type: "string" }, content: { type: "string" } } } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/file/read": {
+    get: { operationId: "bruce_file_read", summary: "Read text content from an allowed file path", responses: makeStandardResponses() }
+  },
+  "/bruce/inbox/check": {
+    get: { operationId: "bruce_inbox_check", summary: "Check inbox source for new items", responses: makeStandardResponses() }
+  },
+  "/bruce/inbox/ingest": {
+    post: {
+      operationId: "bruce_inbox_ingest",
+      summary: "Ingest new inbox items into the system",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", additionalProperties: true } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/archive/check": {
+    get: { operationId: "bruce_archive_check", summary: "Check archive source for new items", responses: makeStandardResponses() }
+  },
+  "/bruce/archive/ingest": {
+    post: {
+      operationId: "bruce_archive_ingest",
+      summary: "Ingest archived items into the system",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", additionalProperties: true } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/health": {
+    get: { operationId: "bruce_health_verbose", summary: "Get detailed BRUCE health status", responses: makeStandardResponses() }
+  },
+  "/bruce/state": {
+    get: { operationId: "bruce_state", summary: "Get gateway runtime state snapshot", responses: makeStandardResponses() }
+  },
+  "/bruce/topology": {
+    get: { operationId: "bruce_topology", summary: "Get current service topology overview", responses: makeStandardResponses() }
+  },
+  "/bruce/maintenance/run": {
+    post: {
+      operationId: "bruce_maintenance_run",
+      summary: "Run configured maintenance workflow",
+      requestBody: { required: false, content: { "application/json": { schema: { type: "object", additionalProperties: true } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/sync/homelab-hub": {
+    post: {
+      operationId: "bruce_sync_homelab_hub",
+      summary: "Trigger synchronization with homelab hub",
+      requestBody: { required: false, content: { "application/json": { schema: { type: "object", additionalProperties: true } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/integrity": {
+    get: { operationId: "bruce_integrity", summary: "Run integrity checks across gateway resources", responses: makeStandardResponses() }
+  },
+  "/bruce/bootstrap": {
+    post: {
+      operationId: "bruce_bootstrap",
+      summary: "Bootstrap BRUCE runtime prerequisites",
+      requestBody: { required: false, content: { "application/json": { schema: { type: "object", additionalProperties: true } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/llm/status": {
+    get: { operationId: "bruce_llm_status", summary: "Get LLM provider connectivity and status", responses: makeStandardResponses() }
+  },
+  "/bruce/tool-check": {
+    post: {
+      operationId: "bruce_tool_check",
+      summary: "Validate tool availability for a given request",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", additionalProperties: true } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/tools/rag/search": {
+    post: {
+      operationId: "tools_rag_search",
+      summary: "Run RAG search through tools compatibility endpoint",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", required: ["q"], properties: { q: { type: "string" } } } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/preflight": {
+    post: {
+      operationId: "bruce_preflight",
+      summary: "Run preflight checks before tool or chat execution",
+      requestBody: { required: false, content: { "application/json": { schema: { type: "object", additionalProperties: true } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/roadmap/done": {
+    post: {
+      operationId: "bruce_roadmap_done",
+      summary: "Mark a roadmap task as completed",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", required: ["id"], properties: { id: { type: "string" } } } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/search": {
+    post: {
+      operationId: "bruce_search",
+      summary: "Search data with scoped access control",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", required: ["query"], properties: { query: { type: "string" } } } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/session/init": {
+    post: {
+      operationId: "bruce_session_init",
+      summary: "Initialize a new BRUCE session",
+      requestBody: { required: false, content: { "application/json": { schema: { type: "object", additionalProperties: true } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/session/close/checklist": {
+    get: { operationId: "bruce_session_close_checklist", summary: "Get checklist required before closing session", responses: makeStandardResponses() }
+  },
+  "/bruce/session/close": {
+    post: {
+      operationId: "bruce_session_close",
+      summary: "Close an active BRUCE session",
+      requestBody: { required: false, content: { "application/json": { schema: { type: "object", additionalProperties: true } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/staging/validate": {
+    post: {
+      operationId: "bruce_staging_validate",
+      summary: "Validate staged changes before apply",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", additionalProperties: true } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/staging/status": {
+    get: { operationId: "bruce_staging_status", summary: "Get staging workspace status", responses: makeStandardResponses() }
+  },
+  "/chat": {
+    post: {
+      operationId: "chat",
+      summary: "Run legacy BRUCE chat endpoint",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", additionalProperties: true } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/api/openai/v1/models": {
+    get: { operationId: "openai_models_api", summary: "OpenAI-compatible models endpoint alias", responses: makeStandardResponses() }
+  },
+  "/v1/models": {
+    get: { operationId: "openai_models", summary: "OpenAI-compatible models endpoint", responses: makeStandardResponses() }
+  },
+  "/api/openai/v1/chat/completions": {
+    post: {
+      operationId: "openai_chat_completions_api",
+      summary: "OpenAI-compatible chat completions endpoint alias",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", additionalProperties: true } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/v1/chat/completions": {
+    post: {
+      operationId: "openai_chat_completions",
+      summary: "OpenAI-compatible chat completions endpoint",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", additionalProperties: true } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/llm/generate": {
+    post: {
+      operationId: "bruce_llm_generate",
+      summary: "Generate completion from configured LLM",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", additionalProperties: true } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/agent/chat": {
+    post: {
+      operationId: "bruce_agent_chat",
+      summary: "Run BRUCE agent chat orchestration",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", additionalProperties: true } } } },
+      responses: makeStandardResponses()
+    }
+  },
+  "/bruce/ask": {
+    post: {
+      operationId: "bruce_ask",
+      summary: "Ask BRUCE a direct question and get an answer",
+      requestBody: { required: true, content: { "application/json": { schema: { type: "object", required: ["question"], properties: { question: { type: "string" } } } } } },
+      responses: makeStandardResponses()
+    }
+  }
+});
 
 
 app.get("/openapi.json", (req, res) => {


### PR DESCRIPTION
### Motivation

- Reduce repetition in the in-code OpenAPI spec by centralizing common response schemas and streamline adding new endpoints.
- Provide a consistent set of standard responses and tighten request bodies for several tool endpoints to better document required fields.
- Expand the published OpenAPI surface so external tools can discover many BRUCE gateway endpoints and their basic request/response shapes.

### Description

- Introduced a shared `jsonObjectSchema` constant and replaced repeated `{ type: "object", additionalProperties: true }` occurrences with this reusable schema.
- Added a `makeStandardResponses()` helper that returns standardized `200`, `400`, `401`, and `500` responses and applied it across many endpoints to DRY response definitions.
- Bulk-merged many endpoint definitions into `BRUCE_OPENAPI_SPEC.paths` using `Object.assign`, including admin, connectors, manual, tools, browser helpers, docker, exec/file/inbox/archive/health/maintenance, session/staging, search/session/roadmap, OpenAI-compatible routes, agent/chat, RAG/tools, and others, with several request bodies tightened to require fields like `sql`, `url`, `cmd`, `path`/`content`, `q`, `query`, `id`, or `question` where appropriate.
- Removed the old inline PATCH-style block and consolidated OpenAPI construction for clarity and maintainability while keeping the `/openapi.json` route behavior unchanged.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d1a862e883279f483edf67b09424)