### PR TITLE
[951] Rendre les tests exécutables

### DIFF
--- a/mcp-gateway/jest.config.js
+++ b/mcp-gateway/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  testMatch: ['**/tests/**/*.test.js'],
+  testEnvironment: 'node',
+  testTimeout: 10000,
+};

--- a/mcp-gateway/package.json
+++ b/mcp-gateway/package.json
@@ -4,7 +4,10 @@
   "description": "MCP Gateway for Yann's homelab",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "jest --verbose",
+    "test:unit": "jest tests/unit --verbose",
+    "test:integration": "jest tests/integration --verbose"
   },
   "dependencies": {
     "better-sqlite3": "^12.6.2",
@@ -12,5 +15,9 @@
     "express": "^4.19.2",
     "node-ssh": "^13.2.1",
     "sqlite3": "^5.1.7"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
   }
 }


### PR DESCRIPTION
### Motivation
- Le dépôt contient des fichiers de tests mais ils n'étaient pas exécutables parce que `jest` et `supertest` n'étaient pas déclarés et il n'y avait pas de script `npm test`.
- Les tests d'intégration peuvent nécessiter un délai plus long, d'où la configuration d'un `testTimeout` approprié.

### Description
- Ajout des scripts `test`, `test:unit` et `test:integration` dans `mcp-gateway/package.json` pour exécuter les tests via `jest`.
- Ajout de `devDependencies` dans `mcp-gateway/package.json` avec `jest@^29.7.0` et `supertest@^6.3.4`.
- Création de `mcp-gateway/jest.config.js` avec `testMatch: ['**/tests/**/*.test.js']`, `testEnvironment: 'node'` et `testTimeout: 10000`.
- Aucun fichier de test existant n'a été modifié et aucune autre dépendance n'a été ajoutée.

### Testing
- Exécution de `npm --prefix mcp-gateway pkg get scripts devDependencies` pour vérifier que les scripts et `devDependencies` ont été ajoutés, et la commande a renvoyé les valeurs attendues.
- Les modifications ont été validées localement en affichant le contenu de `mcp-gateway/package.json` et `mcp-gateway/jest.config.js` pour confirmer la configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5e15a984c832793964c2a07b5d423)