### PR TITLE
fix: flatten connectors.json envelope for connector ping compatibility

### DIFF
--- a/mcp-gateway/connectors.json
+++ b/mcp-gateway/connectors.json
@@ -1,28 +1,26 @@
-{
-  "connectors": [
-    {
-      "id": "supabase_main",
-      "name": "Supabase main project",
-      "status": "ok",
-      "url": "http://192.168.2.146:3000"
-    },
-    {
-      "id": "n8n",
-      "name": "n8n automations",
-      "status": "planned",
-      "url": "http://192.168.2.231:5678"
-    },
-    {
-      "id": "openwebui",
-      "name": "OpenWebUI (furycomai)",
-      "status": "planned",
-      "url": "http://192.168.2.230:8080"
-    },
-    {
-      "id": "ollama",
-      "name": "Ollama (furycomai)",
-      "status": "planned",
-      "url": "http://192.168.2.230:11434"
-    }
-  ]
-}
+[
+  {
+    "id": "supabase_main",
+    "name": "Supabase main project",
+    "status": "ok",
+    "url": "http://192.168.2.146:3000"
+  },
+  {
+    "id": "n8n",
+    "name": "n8n automations",
+    "status": "planned",
+    "url": "http://192.168.2.231:5678"
+  },
+  {
+    "id": "openwebui",
+    "name": "OpenWebUI (furycomai)",
+    "status": "planned",
+    "url": "http://192.168.2.230:8080"
+  },
+  {
+    "id": "ollama",
+    "name": "Ollama (furycomai)",
+    "status": "planned",
+    "url": "http://192.168.2.230:11434"
+  }
+]


### PR DESCRIPTION
### Motivation
- The connectors file used a top-level envelope `{ "connectors": [...] }` which caused `Object.values()` in the route to treat the array as a single element and break connector pinging.  

### Description
- Replace `mcp-gateway/connectors.json` contents with a flat JSON array (`[...]`) preserving all connector objects, fields, and values exactly, so `routes/connectors.js` can iterate connector objects correctly.  

### Testing
- Validated the file is well-formed JSON with `python -m json.tool mcp-gateway/connectors.json` and inspected the change with `git diff -- mcp-gateway/connectors.json`; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5e17e5c4c8327ab6909a3a349fd9a)